### PR TITLE
Conversion of p to a numeric slot in dgCMatrix

### DIFF
--- a/pkg/Matrix/R/AllClass.R
+++ b/pkg/Matrix/R/AllClass.R
@@ -149,7 +149,7 @@ setClass("TsparseMatrix", contains = c("sparseMatrix", "VIRTUAL"),
          )
 
 setClass("CsparseMatrix", contains = c("sparseMatrix", "VIRTUAL"),
-	 slots = c(i = "integer", p = "integer"),
+	 slots = c(i = "integer", p = "numeric"),
 	 prototype = prototype(p = 0L),# to be valid
          validity = function(object) .Call(Csparse_validate, object)
          )

--- a/pkg/Matrix/src/Mutils.h
+++ b/pkg/Matrix/src/Mutils.h
@@ -274,6 +274,17 @@ int* expand_cmprPt(int ncol, const int mp[], int mj[])
     return mj;
 }
 
+static R_INLINE
+int* expand_cmprPt_dbl(int ncol, const double mp[], int mj[])
+{
+    int j;
+    for (j = 0; j < ncol; j++) {
+	double j2 = mp[j+1], jj;
+	for (jj = mp[j]; jj < j2; jj++) mj[(int)jj] = j;
+    }
+    return mj;
+}
+
 /**
  * Check if slot(obj, "x") contains any NA (or NaN).
  *


### PR DESCRIPTION
@mmaechler: following up one what we discussed offline, I've started giving this a shot. Currently I've got the most basic example working with `show` and `as.matrix` now handling double-precision `p`:

```r
library(Matrix)
new("dgCMatrix", i=1:2, p=c(0L, 2L, 2L), x=1:2+0, Dim=c(5L, 2L))
new("dgCMatrix", i=1:2, p=c(0L, 2, 2), x=1:2+0, Dim=c(5L, 2L)) # same output
```

My general strategy is to throw `p`-related code into macros - I'm told that this is the way to re-use code for different types. Seems a bit awkward, but oh well.

Even in just this simple example, I already note a possible problem: `compressed_non_0_ij` creates a matrix with number of rows equal to the number of non-zero entries, but `allocMatrix` only allows `int` specification of the dimensions. This results in an integer overflow when we have enough non-zero entries (which is the whole motivation for changing `p` in the first place). The solution would be to allow `compressed_non_0_ij` to return two `i` and `j` vectors, but this requires more changes elsewhere so I have just let it be for the time being.

For the CHOLMOD-interfacing code in `as_cholmod_sparse`, I am just copying the double `p` into an integer array for now, until the relevant typedef switches from `int` to `long int`.

If you think this is the right way forward, I will proceed to convert other `dgCMatrix`-related functionality, one bit at a time. 